### PR TITLE
Python terraform 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ python-terraform is a python module provide a wrapper of `terraform` command lin
     t = Terraform()
     return_code, stdout, stderr = t.<cmd_name>(*arguments, **options)
 
-**Note**: method name same as reserved keyword like `import` could be called directly
-by adding `_cmd` after command name
+**Note**: method name same as reserved keyword like `import` won't be accepted by python interpreter,
+to be able to call the method, you could call cmd_name by adding `_cmd` after command name, for example,
+`import` here could be called by
 
     from python_terraform import Terraform
     t = Terraform()
-    return_code, stdout, stderr = t.<cmd_name>_cmd(*arguments, **options)
+    return_code, stdout, stderr = t.import_cmd(*arguments, **options)
 
 or just call cmd method directly
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,25 @@ python-terraform is a python module provide a wrapper of `terraform` command lin
     pip install python-terraform
     
 ## Usage
-####For any terraform command
+#### For any terraform command
 
     from python_terraform import Terraform
     t = Terraform()
     return_code, stdout, stderr = t.<cmd_name>(*arguments, **options)
+
+**Note**: method name same as reserved keyword like `import` could be called directly by using the following
+
+    from python_terraform import Terraform
+    t = Terraform()
+    return_code, stdout, stderr = t.<cmd_name>_method(*arguments, **options)
+
+or just call cmd method directly
+
+    from python_terraform import Terraform
+    t = Terraform()
+    return_code, stdout, stderr = t.cmd(<cmd_name>, *arguments, **options)
     
-####For any argument
+#### For any argument
 simply pass the string to arguments of the method, for example,
 
     terraform apply target_dir 
@@ -24,7 +36,7 @@ simply pass the string to arguments of the method, for example,
     terraform import aws_instance.foo i-abcd1234 
         --> <instance>.import('aws_instance.foo', 'i-abcd1234')
 
-####For any options
+#### For any options
     
 * dash to underscore
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ python-terraform is a python module provide a wrapper of `terraform` command lin
     t = Terraform()
     return_code, stdout, stderr = t.<cmd_name>(*arguments, **options)
 
-**Note**: method name same as reserved keyword like `import` could be called directly by using the following
+**Note**: method name same as reserved keyword like `import` could be called directly
+by adding `_cmd` after command name
 
     from python_terraform import Terraform
     t = Terraform()
-    return_code, stdout, stderr = t.<cmd_name>_method(*arguments, **options)
+    return_code, stdout, stderr = t.<cmd_name>_cmd(*arguments, **options)
 
 or just call cmd method directly
 

--- a/python_terraform/__init__.py
+++ b/python_terraform/__init__.py
@@ -33,8 +33,9 @@ class Terraform(object):
                  variables=None,
                  parallelism=None,
                  var_file=None,
-                 terraform_bin_path=None):
-        """
+                 terraform_bin_path=None,
+                 is_env_vars_included=True):
+        """        
         :param working_dir: the folder of the working folder, if not given,
                             will be current working folder
         :param targets: list of target
@@ -47,7 +48,10 @@ class Terraform(object):
         :param var_file: passed as value of -var-file option,
                 could be string or list, list stands for multiple -var-file option
         :param terraform_bin_path: binary path of terraform
+        :type is_env_vars_included: bool
+        :param is_env_vars_included: included env variables when calling terraform cmd 
         """
+        self.is_env_vars_included = is_env_vars_included
         self.working_dir = working_dir
         self.state = state
         self.targets = [] if targets is None else targets
@@ -225,9 +229,12 @@ class Terraform(object):
 
         working_folder = self.working_dir if self.working_dir else None
 
-        p = subprocess.Popen(cmd_string, stdout=stdout,
-                             stderr=stderr, shell=True,
-                             cwd=working_folder)
+        environ_vars = {}
+        if self.is_env_vars_included:
+            environ_vars = os.environ.copy()
+
+        p = subprocess.Popen(cmd_string, stdout=stdout, stderr=stderr, shell=True,
+                             cwd=working_folder, env=environ_vars)
         out, err = p.communicate()
         ret_code = p.returncode
         log.debug('output: {o}'.format(o=out))

--- a/python_terraform/__init__.py
+++ b/python_terraform/__init__.py
@@ -64,8 +64,11 @@ class Terraform(object):
 
     def __getattr__(self, item):
         def wrapper(*args, **kwargs):
+            cmd_name = str(item)
+            if cmd_name.endswith('_cmd'):
+                cmd_name = cmd_name[:-4]
             logging.debug('called with %r and %r' % (args, kwargs))
-            return self.cmd(item, *args, **kwargs)
+            return self.cmd(cmd_name, *args, **kwargs)
 
         return wrapper
 

--- a/test/import_test/test.tf
+++ b/test/import_test/test.tf
@@ -1,0 +1,7 @@
+provider "archive" {}
+
+data "archive_file" "init" {
+  type        = "zip"
+  source_file = "${path.module}/init.tpl"
+  output_path = "${path.module}/init.zip"
+}

--- a/test/import_test/test.tf
+++ b/test/import_test/test.tf
@@ -1,7 +1,0 @@
-provider "archive" {}
-
-data "archive_file" "init" {
-  type        = "zip"
-  source_file = "${path.module}/init.tpl"
-  output_path = "${path.module}/init.zip"
-}

--- a/test/test_terraform.py
+++ b/test/test_terraform.py
@@ -1,3 +1,7 @@
+try:
+    from cStringIO import StringIO      # Python 2
+except ImportError:
+    from io import StringIO
 from python_terraform import *
 import pytest
 import os
@@ -6,8 +10,9 @@ import re
 import shutil
 
 logging.basicConfig(level=logging.DEBUG)
-ch = logging.StreamHandler(sys.stdout)
-logging.getLogger().addHandler(ch)
+root_logger = logging.getLogger()
+# ch = logging.StreamHandler(sys.stdout)
+# root_logger.addHandler(ch)
 current_path = os.path.dirname(os.path.realpath(__file__))
 
 STRING_CASES = [
@@ -25,18 +30,20 @@ STRING_CASES = [
  ]
 
 CMD_CASES = [
-    ['method', 'expected_output', 'expected_ret_code'],
+    ['method', 'expected_output', 'expected_ret_code', 'expected_logs'],
     [
         [
             lambda x: x.cmd('plan', 'var_to_output', no_color=IsFlagged, var={'test_var': 'test'}) ,
             "doesn't need to do anything",
-            0
+            0,
+            ''
         ],
         # try import aws instance
         [
             lambda x: x.cmd('import', 'aws_instance.foo', 'i-abcd1234', no_color=IsFlagged),
-            'Import complete!',
-            1
+            '',
+            1,
+            'command: terraform import -no-color aws_instance.foo i-abcd1234'
         ]
     ]
 ]
@@ -54,6 +61,19 @@ def fmt_test_file(request):
 
     request.addfinalizer(td)
     return
+
+
+@pytest.fixture()
+def string_logger(request):
+    log_stream = StringIO()
+    handler = logging.StreamHandler(log_stream)
+    root_logger.addHandler(handler)
+
+    def td():
+        root_logger.removeHandler(handler)
+
+    request.addfinalizer(td)
+    return log_stream
 
 
 class TestTerraform(object):
@@ -82,12 +102,14 @@ class TestTerraform(object):
             assert s in result
 
     @pytest.mark.parametrize(*CMD_CASES)
-    def test_cmd(self, method, expected_output, expected_ret_code):
-        os.environ['AWS_DEFAULT_REGION'] = "us-west-1"
+    def test_cmd(self, method, expected_output, expected_ret_code, expected_logs, string_logger):
         tf = Terraform(working_dir=current_path)
         ret, out, err = method(tf)
+        logs = str(string_logger.getvalue())
+        logs = logs.replace('\n', '')
         assert expected_output in out
         assert expected_ret_code == ret
+        assert expected_logs in logs
 
     @pytest.mark.parametrize(
         ("folder", "variables", "var_files", "expected_output", "options"),
@@ -172,9 +194,9 @@ class TestTerraform(object):
         ret, out, err = tf.fmt(diff=True)
         assert ret == 0
 
-    def test_import(self):
-        os.environ['AWS_DEFAULT_REGION'] = "us-west-1"
-        tf = Terraform(working_dir=current_path)
-        ret, out, err = tf.import_cmd('aws_instance.foo', 'i-abc1234', no_color=IsFlagged)
-        assert 'Import complete!' in out
-        assert 1 == ret
+    def test_import(self, string_logger):
+        tf = Terraform(working_dir=os.path.join(current_path, 'import_test'))
+        tf.import_cmd('aws_instance.foo', 'i-abc1234', no_color=IsFlagged)
+        logs = string_logger.getvalue()
+        print(logs)
+        assert 'command: terraform import -no-color aws_instance.foo i-abc1234' in logs

--- a/test/test_terraform.py
+++ b/test/test_terraform.py
@@ -83,6 +83,7 @@ class TestTerraform(object):
 
     @pytest.mark.parametrize(*CMD_CASES)
     def test_cmd(self, method, expected_output, expected_ret_code):
+        os.environ['AWS_DEFAULT_REGION'] = "us-west-1"
         tf = Terraform(working_dir=current_path)
         ret, out, err = method(tf)
         assert expected_output in out
@@ -172,6 +173,7 @@ class TestTerraform(object):
         assert ret == 0
 
     def test_import(self):
+        os.environ['AWS_DEFAULT_REGION'] = "us-west-1"
         tf = Terraform(working_dir=current_path)
         ret, out, err = tf.import_cmd('aws_instance.foo', 'i-abc1234', no_color=IsFlagged)
         assert 'Import complete!' in out

--- a/test/test_terraform.py
+++ b/test/test_terraform.py
@@ -195,7 +195,7 @@ class TestTerraform(object):
         assert ret == 0
 
     def test_import(self, string_logger):
-        tf = Terraform(working_dir=os.path.join(current_path, 'import_test'))
+        tf = Terraform(working_dir=current_path)
         tf.import_cmd('aws_instance.foo', 'i-abc1234', no_color=IsFlagged)
         logs = string_logger.getvalue()
         print(logs)

--- a/test/test_terraform.py
+++ b/test/test_terraform.py
@@ -173,5 +173,6 @@ class TestTerraform(object):
 
     def test_import(self):
         tf = Terraform(working_dir=current_path)
-        tf.cmd('import', 'aws_instance.foo', 'i-abc123')
-        assert False
+        ret, out, err = tf.import_cmd('aws_instance.foo', 'i-abc1234', no_color=IsFlagged)
+        assert 'Import complete!' in out
+        assert 1 == ret

--- a/test/vars_require_input/main.tf
+++ b/test/vars_require_input/main.tf
@@ -10,7 +10,7 @@ variable "list" {
 
 variable "map" {
   default = {}
-  type = "map"
+  type    = "map"
 }
 
 resource "aws_instance" "bar" {


### PR DESCRIPTION
fix python-terraform-8, can't call the method when terraform cmd name is same as python reserved keyword