### PR TITLE
Return access to the subprocess so output can be handled as desired

### DIFF
--- a/python_terraform/__init__.py
+++ b/python_terraform/__init__.py
@@ -235,6 +235,11 @@ class Terraform(object):
 
         p = subprocess.Popen(cmd_string, stdout=stdout, stderr=stderr, shell=True,
                              cwd=working_folder, env=environ_vars)
+
+        synchronous = kwargs.pop('synchronous', True)
+        if not synchronous:
+            return p, None, None
+
         out, err = p.communicate()
         ret_code = p.returncode
         log.debug('output: {o}'.format(o=out))

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except IOError:
 
 setup(
     name=module_name,
-    version='0.8.6',
+    version='0.8.7',
     url='https://github.com/beelit94/python-terraform',
     license='MIT',
     author='Freddy Tan',


### PR DESCRIPTION
It might be that none of the options for handling the log is suitable at the moment. In my case I'd like to stream the output from Terraform to the front end of a website. I think in cases like this, it'd be more suitable to have access to the subprocess directly so I can handle it as needed.

This can be done by passing an "synchronous" flag to the method. 

At the moment I'm returning the process plus two None placeholders in case something else is broken because it's expecting three outputs from the method. I'm not sure how to test it to make sure this doesn't impact other parts of the module. Suggestions welcome!
