### PR TITLE
Don't print a warning if there is no message

### DIFF
--- a/python_terraform/__init__.py
+++ b/python_terraform/__init__.py
@@ -296,7 +296,7 @@ class Terraform(object):
 
         if ret_code == 0:
             self.read_state_file()
-        else:
+        elif (ret_code == 2 and len(err) > 0) or ret_code != 2:
             log.warn('error: {e}'.format(e=err))
 
         self.temp_var_files.clean_up()


### PR DESCRIPTION
Only output a warning for return code 2 (changes to be applied) if stderr actually contains a string.