### PR TITLE
bugfix/terraform 12 var-file suffix

### DIFF
--- a/python_terraform/__init__.py
+++ b/python_terraform/__init__.py
@@ -396,7 +396,7 @@ class VariableFiles(object):
         self.files = []
 
     def create(self, variables):
-        with tempfile.NamedTemporaryFile('w+t', delete=False) as temp:
+        with tempfile.NamedTemporaryFile('w+t', suffix='.tfvars.json', delete=False) as temp:
             log.debug('{0} is created'.format(temp.name))
             self.files.append(temp)
             log.debug(


### PR DESCRIPTION
After upgrading to Terraform 12, I was getting the following error when running plan/apply:
```
Error: Argument or block definition required

  on /tmp/tmpcSY9YL line 1:
   1: <input variables dict>

An argument or block definition is required here.
```

After more testing I found that Terraform 12 no longer accepts variable definition files without an extension. This change fixes that problem and has no effect on Terraform versions < 12.

https://www.terraform.io/docs/configuration/variables.html#variable-definitions-tfvars-files

Steps to reproduce this problem:
1. Upgrade to Terraform 12 (still in Beta)
    https://www.terraform.io/upgrade-guides/0-12.html
2. Save a json object in a file with no extension
3. Run terraform plan with that var-file as an input
