### PR TITLE
Pop "synchronous" flag before it affects actual terraform command

### DIFF
--- a/python_terraform/__init__.py
+++ b/python_terraform/__init__.py
@@ -272,6 +272,8 @@ class Terraform(object):
         """
         capture_output = kwargs.pop('capture_output', True)
         raise_on_error = kwargs.pop('raise_on_error', False)
+        synchronous = kwargs.pop('synchronous', True)
+        
         if capture_output is True:
             stderr = subprocess.PIPE
             stdout = subprocess.PIPE
@@ -291,7 +293,6 @@ class Terraform(object):
         p = subprocess.Popen(cmds, stdout=stdout, stderr=stderr,
                              cwd=working_folder, env=environ_vars)
 
-        synchronous = kwargs.pop('synchronous', True)
         if not synchronous:
             return p, None, None
 


### PR DESCRIPTION
Move "synchrounous" pop uphill, so it doesn't end up as a flag in the actual terraform command (and therefore crashes terraform as an unrecognized flag).