### PR TITLE
Fix 'synchronous' option passed to terraform

### DIFF
--- a/python_terraform/__init__.py
+++ b/python_terraform/__init__.py
@@ -283,6 +283,8 @@ class Terraform(object):
         """
         capture_output = kwargs.pop('capture_output', True)
         raise_on_error = kwargs.pop('raise_on_error', False)
+        synchronous = kwargs.pop('synchronous', True)
+        
         if capture_output is True:
             stderr = subprocess.PIPE
             stdout = subprocess.PIPE
@@ -302,7 +304,6 @@ class Terraform(object):
         p = subprocess.Popen(cmds, stdout=stdout, stderr=stderr,
                              cwd=working_folder, env=environ_vars)
 
-        synchronous = kwargs.pop('synchronous', True)
         if not synchronous:
             return p, None, None
 


### PR DESCRIPTION
When the 'synchronous' option is not poped before calling generate_cmd_string(), it get in the terraform option and cause it to fail, making the 'synchronous' unusable.