### PR TITLE
Replace deprecated warn with warning

### DIFF
--- a/python_terraform/__init__.py
+++ b/python_terraform/__init__.py
@@ -314,7 +314,7 @@ class Terraform(object):
         if ret_code == 0:
             self.read_state_file()
         else:
-            log.warn('error: {e}'.format(e=err))
+            log.warning('error: {e}'.format(e=err))
 
         self.temp_var_files.clean_up()
         if capture_output is True:


### PR DESCRIPTION
```
(python-terraform) ➜  python-terraform git:(develop) ✗ pytest test                                            
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.8, pytest-5.2.1, py-1.8.0, pluggy-0.13.0
rootdir: /home/noname/Projects/python-terraform
collected 37 items                                                                                                                                                                           

test/test_terraform.py .....................................                                                                                                                           [100%]

====================================================================================== warnings summary ======================================================================================
test/test_terraform.py::TestTerraform::test_cmd[<lambda>--1-False-command: terraform import -no-color aws_instance.foo i-abcd1234-]
test/test_terraform.py::TestTerraform::test_cmd[<lambda>--1-True-command: terraform import -no-color aws_instance.foo i-abcd1234-]
test/test_terraform.py::TestTerraform::test_apply_with_var_file
test/test_terraform.py::TestTerraform::test_output[param1]
test/test_terraform.py::TestTerraform::test_output_full_value[param1]
test/test_terraform.py::TestTerraform::test_output_all[param1]
test/test_terraform.py::TestTerraform::test_plan[vars_require_input-variables0-1]
test/test_terraform.py::TestTerraform::test_import
  /home/noname/Projects/python-terraform/python_terraform/__init__.py:317: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    log.warn('error: {e}'.format(e=err))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================= 37 passed, 8 warnings in 139.23s (0:02:19) =========================================================================
```