### PR TITLE
fixes 0.12 path.module resolution

### DIFF
--- a/python_terraform/__init__.py
+++ b/python_terraform/__init__.py
@@ -301,8 +301,9 @@ class Terraform(object):
         if self.is_env_vars_included:
             environ_vars = os.environ.copy()
 
+        cmds.append(working_folder)
         p = subprocess.Popen(cmds, stdout=stdout, stderr=stderr,
-                             cwd=working_folder, env=environ_vars)
+                             env=environ_vars)
 
         if not synchronous:
             return p, None, None


### PR DESCRIPTION
0.12.x changed how `${path.module}` is rendered, and since `python-terraform` isn't explicitly passing a path to the terraform binary, terraform is using the implied value of `.` instead of the full path cwd.

This patch explicitly passes the path to the terraform binary when `Popen()` is called, which restores the old behavior in <0.11.x. Basically, it stops `chdir()` into the terraform root directory and passes the directory to terraform instead. 

This was a drop in replacement in my testing that fixed the problem outright. The only other things I had to change in my code were paths being passed to `backend_config` since terraform is being called from a different directory now (the root of the project rather than the terraform root).

It's very possible this breaks other peoples configurations, and this problem was unique to my workflow. If that's the case feel free to reject the patch. Just passing up what worked for me in case it can help others. 

Thank you for your time and attention