### PR TITLE
Fix for subprocess call for Robot Framework execution

### DIFF
--- a/python_terraform/__init__.py
+++ b/python_terraform/__init__.py
@@ -288,6 +288,9 @@ class Terraform(object):
         if capture_output is True:
             stderr = subprocess.PIPE
             stdout = subprocess.PIPE
+        elif capture_output == "framework":
+            stderr = None
+            stdout = None
         else:
             stderr = sys.stderr
             stdout = sys.stdout


### PR DESCRIPTION
This change modifies behavior of capture_output flag to work with
robot framework. When set to given parameter it'll set stderr and stdout
to None for subprocess command call.
This fixes problem with error: "UnsupportedOperation: fileno"

Signed-off-by: Michal Widera <michal.widera@idemia.com>