### PR TITLE
Return process object asynch

### DIFF
--- a/python_terraform/terraform.py
+++ b/python_terraform/terraform.py
@@ -25,7 +25,7 @@ class IsNotFlagged(TerraformFlag):
     pass
 
 
-CommandOutput = Tuple[Optional[int], Optional[str], Optional[str]]
+CommandOutput = Tuple[Union[int, subprocess.Popen[bytes], None], Optional[str], Optional[str]]
 
 
 class TerraformCommandError(subprocess.CalledProcessError):

--- a/python_terraform/terraform.py
+++ b/python_terraform/terraform.py
@@ -25,7 +25,7 @@ class IsNotFlagged(TerraformFlag):
     pass
 
 
-CommandOutput = Tuple[Union[int, subprocess.Popen[bytes], None], Optional[str], Optional[str]]
+CommandOutput = Tuple[Union[int, subprocess.Popen, None], Optional[str], Optional[str]]
 
 
 class TerraformCommandError(subprocess.CalledProcessError):

--- a/python_terraform/terraform.py
+++ b/python_terraform/terraform.py
@@ -342,7 +342,7 @@ class Terraform:
         )
 
         if not synchronous:
-            return None, None, None
+            return p, None, None
 
         out, err = p.communicate()
         ret_code = p.returncode


### PR DESCRIPTION
In the old `python-terraform` code, the Popen object was returned in `synchronous=True` mode. My team needs this functionality to be able to tee the terraform output to stdout/stderr at the same time we capture the output and use it for internal processing.

I understand it's not ideal to override the returned Tuple in this way, but this PR does document the possible return with type annotations.

If this PR isn't acceptable, is there any other path to getting the process object?