### PR TITLE
Subprocess Error Log Warnings with UTF-8 Decoding

### DIFF
--- a/python_terraform/terraform.py
+++ b/python_terraform/terraform.py
@@ -351,7 +351,7 @@ class Terraform:
         if ret_code == 0:
             self.read_state_file()
         else:
-            logger.warning("error: %s", err)
+            logger.warning("error: %s", err.decode("utf-8"))
 
         self.temp_var_files.clean_up()
         if capture_output is True:


### PR DESCRIPTION
Hi! This module is very useful as a wrapper for the terraform cli. This change is a bit opinionated and perhaps a bit misguided with the additional options available for capturing output, so needless to say please feel free to discard, but I think decoding the error bytes as utf-8 for more readable warning logs or some additional parsing to remove unwanted characters would be nice since as bytes is difficult to ascertain issue.